### PR TITLE
fix: resolve ESLint configs

### DIFF
--- a/apps/web/.eslintrc.js
+++ b/apps/web/.eslintrc.js
@@ -1,7 +1,8 @@
 module.exports = {
   root: true,
-  extends: ["@cursor-usage/config/nextjs"],
+  extends: [require.resolve("@cursor-usage/config/nextjs")],
   parserOptions: {
     project: "./tsconfig.json",
   },
+  ignorePatterns: ["**/*.js"],
 };

--- a/apps/worker/.eslintrc.js
+++ b/apps/worker/.eslintrc.js
@@ -1,7 +1,8 @@
 module.exports = {
   root: true,
-  extends: ["@cursor-usage/config/library"],
+  extends: [require.resolve("@cursor-usage/config/library")],
   parserOptions: {
     project: "./tsconfig.json",
   },
+  ignorePatterns: ["**/*.js"],
 };

--- a/apps/worker/tsconfig.json
+++ b/apps/worker/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "@cursor-usage/config/base.tsconfig.json",
   "compilerOptions": {},
-  "include": ["src"],
+  "include": ["src", "tsup.config.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/packages/db/.eslintrc.js
+++ b/packages/db/.eslintrc.js
@@ -1,7 +1,8 @@
 module.exports = {
   root: true,
-  extends: ["@cursor-usage/config/library"],
+  extends: [require.resolve("@cursor-usage/config/library")],
   parserOptions: {
     project: "./tsconfig.json",
   },
+  ignorePatterns: ["**/*.js"],
 };

--- a/packages/db/tsconfig.json
+++ b/packages/db/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "@cursor-usage/config/base.tsconfig.json",
   "compilerOptions": {},
-  "include": ["src", "prisma"],
+  "include": ["src", "prisma", "tsup.config.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/packages/env/.eslintrc.js
+++ b/packages/env/.eslintrc.js
@@ -1,7 +1,8 @@
 module.exports = {
   root: true,
-  extends: ["@cursor-usage/config/library"],
+  extends: [require.resolve("@cursor-usage/config/library")],
   parserOptions: {
     project: "./tsconfig.json",
   },
+  ignorePatterns: ["**/*.js"],
 };

--- a/packages/types/.eslintrc.js
+++ b/packages/types/.eslintrc.js
@@ -1,7 +1,8 @@
 module.exports = {
   root: true,
-  extends: ["@cursor-usage/config/library"],
+  extends: [require.resolve("@cursor-usage/config/library")],
   parserOptions: {
     project: "./tsconfig.json",
   },
+  ignorePatterns: ["**/*.js"],
 };

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "@cursor-usage/config/base.tsconfig.json",
   "compilerOptions": {},
-  "include": ["src"],
+  "include": ["src", "tsup.config.ts"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Summary
- resolve shared ESLint config via `require.resolve`
- ignore JS config files during linting
- include tsup config files in TypeScript projects

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689b85117b9883278cbf308eca1135e4